### PR TITLE
fix hatch build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,9 @@ path = ".venv-test"
 [tool.hatch.envs.test.scripts]
 unit = "python -m unittest tests/*.py"
 
+[tool.hatch.build.targets.wheel]
+packages = ["crossplane"]
+
 [tool.ruff]
 target-version = "py311"
 exclude = ["crossplane/function/proto/*"]


### PR DESCRIPTION

### Description of your changes

without this change, running 'hatch build' in my environment (Ubuntu LTS 22.04, with python 3.11.6 (from pyenv) with hatch 1.9.0) fails with:

```
  File
"/home/jo.diaz/.local/share/hatch/env/virtual/function-sdk-python/wwDZoZBv/function-sdk-python-build/lib/python3.11/site-packages/hatchling/builders/wheel.py", line 231, in default_only_include
    return self.default_file_selection_options.only_include
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File
"/home/jo.diaz/.pyenv/versions/3.11.6/lib/python3.11/functools.py", line 1001, in __get__
    val = self.func(instance)
          ^^^^^^^^^^^^^^^^^^^
  File
"/home/jo.diaz/.local/share/hatch/env/virtual/function-sdk-python/wwDZoZBv/function-sdk-python-build/lib/python3.11/site-packages/hatchling/builders/wheel.py", line 219, in default_file_selection_options
    raise ValueError(message)
ValueError: Unable to determine which files to ship inside the wheel using the following heuristics:
https://hatch.pypa.io/latest/plugins/builder/wheel/#default-file-selection

At least one file selection option must be defined in the `tool.hatch.build.targets.wheel` table, see:
https://hatch.pypa.io/latest/config/build/

As an example, if you intend to ship a directory named `foo` that resides within a `src` directory located at the root of your project, you can define the following:

[tool.hatch.build.targets.wheel]
packages = ["src/foo"]
```

with the change, the build succeeds


Fixes # 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Added or updated unit tests for my change.~

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
