### PR TITLE
Fix different loop errors on python 3.12

### DIFF
--- a/crossplane/function/runtime.py
+++ b/crossplane/function/runtime.py
@@ -82,6 +82,9 @@ def serve(
     If insecure is true requests will be served insecurely, even if credentials
     are supplied.
     """
+    # Define the loop before the server so everything uses the same loop.
+    loop = asyncio.get_event_loop()
+
     server = grpc.aio.server()
 
     grpcv1beta1.add_FunctionRunnerServiceServicer_to_server(function, server)
@@ -104,7 +107,6 @@ def serve(
         await server.start()
         await server.wait_for_termination()
 
-    loop = asyncio.get_event_loop()
     try:
         loop.run_until_complete(start())
     finally:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ packages = ["crossplane"]
 [tool.ruff]
 target-version = "py311"
 exclude = ["crossplane/function/proto/*"]
-select = [
+lint.select = [
   "A",
   "ARG",
   "ASYNC",
@@ -103,12 +103,12 @@ select = [
   "W",
   "YTT",
 ]
-ignore = ["ISC001"] # Ruff warns this is incompatible with ruff format.
+lint.ignore = ["ISC001"] # Ruff warns this is incompatible with ruff format.
 
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = ["D"] # Don't require docstrings for tests.
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 known-first-party = ["crossplane"]
 
 [tool.ruff.lint.pydocstyle]


### PR DESCRIPTION
### Description of your changes
Moved the loop definition before the server definition so that everything uses the same event loop.
Cleaned up lint configuration warnings.

Fixes https://github.com/crossplane/function-template-python/issues/40 

I have:

- [X] Read and followed Crossplane's [contribution process].
~- [ ] Added or updated unit tests for my change.~

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
