### PR TITLE
fix: recursively convert struct to dict

### DIFF
--- a/crossplane/function/resource.py
+++ b/crossplane/function/resource.py
@@ -42,7 +42,10 @@ def struct_to_dict(s: structpb.Struct) -> dict:
     protobuf struct. This function makes it possible to convert resources to a
     dictionary.
     """
-    return dict(s)
+    return {
+        k: (struct_to_dict(v) if isinstance(v, structpb.Struct) else v)
+        for k, v in s.items()
+    }
 
 
 @dataclasses.dataclass

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -165,6 +165,43 @@ class TestResource(unittest.TestCase):
                 dataclasses.asdict(case.want), dataclasses.asdict(got), "-want, +got"
             )
 
+    def test_struct_to_dict(self) -> None:
+        @dataclasses.dataclass
+        class TestCase:
+            reason: str
+            s: structpb.Struct
+            want: dict
+
+        cases = [
+            TestCase(
+                reason="Convert a struct with no fields to an empty dictionary.",
+                s=structpb.Struct(),
+                want={},
+            ),
+            TestCase(
+                reason="Convert a struct with a single field to a dictionary.",
+                s=structpb.Struct(fields={"foo": structpb.Value(string_value="bar")}),
+                want={"foo": "bar"},
+            ),
+            TestCase(
+                reason="Convert a nested struct to a dictionary.",
+                s=structpb.Struct(
+                    fields={
+                        "foo": structpb.Value(
+                            struct_value=structpb.Struct(
+                                fields={"bar": structpb.Value(string_value="baz")}
+                            )
+                        )
+                    }
+                ),
+                want={"foo": {"bar": "baz"}},
+            ),
+        ]
+
+        for case in cases:
+            got = resource.struct_to_dict(case.s)
+            self.assertEqual(case.want, got, "-want, +got")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Description of your changes
Converting metadata struct to a dict should return a nested dict, rather than a dict with e.g. annotations as a struct.

I have:

    Read and followed Crossplane's [contribution process](https://git.io/fj2m9).
    - [X] Added or updated unit tests for my change.