### PR TITLE
fix: convert listValues to lists in nested structs

### DIFF
--- a/crossplane/function/proto/v1/run_function_pb2_grpc.py
+++ b/crossplane/function/proto/v1/run_function_pb2_grpc.py
@@ -5,7 +5,7 @@ import warnings
 
 from crossplane.function.proto.v1 import run_function_pb2 as crossplane_dot_function_dot_proto_dot_v1_dot_run__function__pb2
 
-GRPC_GENERATED_VERSION = '1.66.0'
+GRPC_GENERATED_VERSION = '1.66.2'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/crossplane/function/proto/v1/run_function_pb2_grpc.py
+++ b/crossplane/function/proto/v1/run_function_pb2_grpc.py
@@ -5,7 +5,7 @@ import warnings
 
 from crossplane.function.proto.v1 import run_function_pb2 as crossplane_dot_function_dot_proto_dot_v1_dot_run__function__pb2
 
-GRPC_GENERATED_VERSION = '1.66.2'
+GRPC_GENERATED_VERSION = '1.67.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/crossplane/function/proto/v1beta1/run_function_pb2_grpc.py
+++ b/crossplane/function/proto/v1beta1/run_function_pb2_grpc.py
@@ -5,7 +5,7 @@ import warnings
 
 from crossplane.function.proto.v1beta1 import run_function_pb2 as crossplane_dot_function_dot_proto_dot_v1beta1_dot_run__function__pb2
 
-GRPC_GENERATED_VERSION = '1.66.2'
+GRPC_GENERATED_VERSION = '1.67.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/crossplane/function/proto/v1beta1/run_function_pb2_grpc.py
+++ b/crossplane/function/proto/v1beta1/run_function_pb2_grpc.py
@@ -5,7 +5,7 @@ import warnings
 
 from crossplane.function.proto.v1beta1 import run_function_pb2 as crossplane_dot_function_dot_proto_dot_v1beta1_dot_run__function__pb2
 
-GRPC_GENERATED_VERSION = '1.66.0'
+GRPC_GENERATED_VERSION = '1.66.2'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/crossplane/function/resource.py
+++ b/crossplane/function/resource.py
@@ -18,6 +18,7 @@ import dataclasses
 import datetime
 
 import pydantic
+from google.protobuf import json_format
 from google.protobuf import struct_pb2 as structpb
 
 import crossplane.function.proto.v1.run_function_pb2 as fnv1
@@ -69,10 +70,7 @@ def struct_to_dict(s: structpb.Struct) -> dict:
     protobuf struct. This function makes it possible to convert resources to a
     dictionary.
     """
-    return {
-        k: (struct_to_dict(v) if isinstance(v, structpb.Struct) else v)
-        for k, v in s.items()
-    }
+    return json_format.MessageToDict(s, preserving_proto_field_name=True)
 
 
 @dataclasses.dataclass

--- a/crossplane/function/resource.py
+++ b/crossplane/function/resource.py
@@ -58,9 +58,7 @@ def dict_to_struct(d: dict) -> structpb.Struct:
     function makes it possible to work with a Python dict, then convert it to a
     struct in a RunFunctionResponse.
     """
-    s = structpb.Struct()
-    s.update(d)
-    return s
+    return json_format.ParseDict(d, structpb.Struct())
 
 
 def struct_to_dict(s: structpb.Struct) -> dict:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,9 +17,9 @@ classifiers = [
 ]
 
 dependencies = [
-  "grpcio==1.*",
+  "grpcio==1.67.0",
   "grpcio-reflection==1.*",
-  "protobuf==5.28.3",
+  "protobuf==5.27.2",
   "pydantic==2.*",
   "structlog==24.*",
 ]
@@ -44,7 +44,7 @@ dependencies = ["ipython==8.28.0"]
 type = "virtual"
 detached = true
 path = ".venv-generate"
-dependencies = ["grpcio-tools==1.66.2"]
+dependencies = ["grpcio-tools==1.67.0"]
 
 [tool.hatch.envs.generate.scripts]
 protoc = "python -m grpc_tools.protoc --proto_path=. --python_out=. --pyi_out=. --grpc_python_out=. crossplane/function/proto/v1beta1/run_function.proto crossplane/function/proto/v1/run_function.proto"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 dependencies = [
   "grpcio==1.*",
   "grpcio-reflection==1.*",
-  "protobuf==5.27.2",
+  "protobuf==5.28.3",
   "pydantic==2.*",
   "structlog==24.*",
 ]

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -275,6 +275,28 @@ class TestResource(unittest.TestCase):
                 ),
                 want={"foo": {"bar": "baz"}},
             ),
+            TestCase(
+                reason="Convert a nested struct containing ListValues to a dictionary.",
+                s=structpb.Struct(
+                    fields={
+                        "foo": structpb.Value(
+                            struct_value=structpb.Struct(
+                                fields={
+                                    "bar": structpb.Value(
+                                        list_value=structpb.ListValue(
+                                            values=[
+                                                structpb.Value(string_value="baz"),
+                                                structpb.Value(string_value="qux"),
+                                            ]
+                                        )
+                                    )
+                                }
+                            )
+                        )
+                    }
+                ),
+                want={"foo": {"bar": ["baz", "qux"]}},
+            ),
         ]
 
         for case in cases:

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -244,6 +244,66 @@ class TestResource(unittest.TestCase):
                 dataclasses.asdict(case.want), dataclasses.asdict(got), "-want, +got"
             )
 
+    def test_dict_to_struct(self) -> None:
+        @dataclasses.dataclass
+        class TestCase:
+            reason: str
+            d: dict
+            want: structpb.Struct
+
+        cases = [
+            TestCase(
+                reason="Convert an empty dictionary to a struct.",
+                d={},
+                want=structpb.Struct(),
+            ),
+            TestCase(
+                reason="Convert a dictionary with a single field to a struct.",
+                d={"foo": "bar"},
+                want=structpb.Struct(
+                    fields={"foo": structpb.Value(string_value="bar")}
+                ),
+            ),
+            TestCase(
+                reason="Convert a nested dictionary to a struct.",
+                d={"foo": {"bar": "baz"}},
+                want=structpb.Struct(
+                    fields={
+                        "foo": structpb.Value(
+                            struct_value=structpb.Struct(
+                                fields={"bar": structpb.Value(string_value="baz")}
+                            )
+                        )
+                    }
+                ),
+            ),
+            TestCase(
+                reason="Convert a nested dictionary containing lists to a struct.",
+                d={"foo": {"bar": ["baz", "qux"]}},
+                want=structpb.Struct(
+                    fields={
+                        "foo": structpb.Value(
+                            struct_value=structpb.Struct(
+                                fields={
+                                    "bar": structpb.Value(
+                                        list_value=structpb.ListValue(
+                                            values=[
+                                                structpb.Value(string_value="baz"),
+                                                structpb.Value(string_value="qux"),
+                                            ]
+                                        )
+                                    )
+                                }
+                            )
+                        )
+                    }
+                ),
+            ),
+        ]
+        for case in cases:
+            got = resource.dict_to_struct(case.d)
+            self.assertEqual(case.want, got, "-want, +got")
+
     def test_struct_to_dict(self) -> None:
         @dataclasses.dataclass
         class TestCase:


### PR DESCRIPTION
Description of your changes

When converting a struct to dict, it is expected for all the fields to be python-bultins. This includes that the resulting nested dict should not contain ListValues but lists.

I have:

Read and followed Crossplane's [contribution process](https://git.io/fj2m9).
- [X] Added or updated unit tests for my change.
