### PR TITLE
Bump protobuf and add defensive checks to get_* helpers

### DIFF
--- a/crossplane/function/resource.py
+++ b/crossplane/function/resource.py
@@ -110,10 +110,10 @@ def get_condition(resource: structpb.Struct, typ: str) -> Condition:
     """
     unknown = Condition(typ=typ, status="Unknown")
 
-    if "status" not in resource:
+    if not resource or "status" not in resource:
         return unknown
 
-    if "conditions" not in resource["status"]:
+    if not resource["status"] or "conditions" not in resource["status"]:
         return unknown
 
     for c in resource["status"]["conditions"]:
@@ -149,9 +149,9 @@ class Credentials:
 def get_credentials(req: structpb.Struct, name: str) -> Credentials:
     """Get the supplied credentials."""
     empty = Credentials(type="data", data={})
-    if "credentials" not in req:
+    if not req or "credentials" not in req:
         return empty
-    if name not in req["credentials"]:
+    if not req["credentials"] or name not in req["credentials"]:
         return empty
     return Credentials(
         type=req["credentials"][name]["type"],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 dependencies = [
   "grpcio==1.*",
   "grpcio-reflection==1.*",
-  "protobuf==5.27.2",
+  "protobuf==5.28.1",
   "pydantic==2.*",
   "structlog==24.*",
 ]


### PR DESCRIPTION
Bump protobuf to match the generated code and add defensive checks required by the latest protobuf library.

There are some issues with protobuf and empty dictionaries as documented here:  https://github.com/protocolbuffers/protobuf/issues/19624 so in the mean time check to make sure the empty dict/struct doesn't get handled by protobuf.

I have:

- [X] Read and followed Crossplane's [contribution process].
~- [ ] Added or updated unit tests for my change.~

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
