### PR TITLE
Actually enable debug logs if requested

### DIFF
--- a/crossplane/function/logging.py
+++ b/crossplane/function/logging.py
@@ -75,7 +75,7 @@ def configure(level: Level = Level.INFO) -> None:
             structlog.processors.EventRenamer(to="msg"),
             structlog.processors.JSONRenderer(),
         ],
-        wrapper_class=structlog.make_filtering_bound_logger(logging.INFO),
+        wrapper_class=structlog.make_filtering_bound_logger(logging.DEBUG if level == Level.DEBUG else logging.INFO),
     )
 
 


### PR DESCRIPTION
I noticed that when enabling debug logs, the level doesn't actually get set. This should fix that.

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

You MUST either [x] check or ~strikethrough~ every item in the checklist below.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes # 

I have:

- [X] Read and followed Crossplane's [contribution process].
- [ ] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
