### PR TITLE
Pydantic, exclude_defaults=True re-add `apiVersion` and `kind`

### DIFF
--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -90,7 +90,11 @@ class TestResource(unittest.TestCase):
                 ),
                 want=fnv1.Resource(
                     resource=resource.dict_to_struct(
-                        {"spec": {"forProvider": {"region": "us-west-2"}}}
+                        {
+                            "apiVersion": "s3.aws.upbound.io/v1beta1",
+                            "kind": "Bucket",
+                            "spec": {"forProvider": {"region": "us-west-2"}},
+                        }
                     ),
                 ),
             ),

--- a/tests/testdata/models/io/upbound/aws/s3/v1beta2.py
+++ b/tests/testdata/models/io/upbound/aws/s3/v1beta2.py
@@ -759,11 +759,11 @@ class Status(BaseModel):
 
 
 class Bucket(BaseModel):
-    apiVersion: Optional[str] = None
+    apiVersion: Optional[str] = 's3.aws.upbound.io/v1beta2'
     """
     APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
     """
-    kind: Optional[str] = None
+    kind: Optional[str] = 'Bucket'
     """
     Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
     """


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
In Pydantic, exclude_defaults=True in model_dump excludes fields that have their value equal to the default. If a field like
`apiVersion` is set to its default value 's3.aws.upbound.io/v1beta2' (and not explicitly provided during initialization), it will be excluded from the serialized output.

so we will explicit add apiVersion and kind 

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

You MUST either [x] check or ~strikethrough~ every item in the checklist below.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes # 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute

# Tests

tested via

```
dependencies = [
  "click==8.1.7",
  "grpcio==1.66.2",
  "crossplane-function-sdk-python @ git+https://github.com/haarchri/function-sdk-python@test"
]

[tool.hatch.metadata]
allow-direct-references = true
```

before:
```
up composition render  apis/xstoragebuckets/composition.yaml examples/storagebucket/example.yaml
---
apiVersion: platform.example.com/v1alpha1
kind: XStorageBucket
metadata:
  name: example
status:
  conditions:
  - lastTransitionTime: "2024-01-01T00:00:00Z"
    message: 'Unready resources: bucket'
    reason: Creating
    status: "False"
    type: Ready
---
metadata:
  annotations:
    crossplane.io/composition-resource-name: bucket
  generateName: example-
  labels:
    crossplane.io/composite: example
  ownerReferences:
  - apiVersion: platform.example.com/v1alpha1
    blockOwnerDeletion: true
    controller: true
    kind: XStorageBucket
    name: example
    uid: ""
spec:
  forProvider:
    region: us-west-1
```

—

with this PR:
```
up composition render  apis/xstoragebuckets/composition.yaml examples/storagebucket/example.yaml
---
apiVersion: platform.example.com/v1alpha1
kind: XStorageBucket
metadata:
  name: example
status:
  conditions:
  - lastTransitionTime: "2024-01-01T00:00:00Z"
    message: 'Unready resources: bucket'
    reason: Creating
    status: "False"
    type: Ready
---
apiVersion: s3.aws.upbound.io/v1beta1
kind: Bucket
metadata:
  annotations:
    crossplane.io/composition-resource-name: bucket
  generateName: example-
  labels:
    crossplane.io/composite: example
  ownerReferences:
  - apiVersion: platform.example.com/v1alpha1
    blockOwnerDeletion: true
    controller: true
    kind: XStorageBucket
    name: example
    uid: ""
spec:
  forProvider:
    region: us-west-1
```
