### PR TITLE
Let tools know this library supports type hints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ classifiers = [
   "Development Status :: 4 - Beta",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3.11",
+  "Typing :: Typed",
 ]
 
 dependencies = [
@@ -63,7 +64,7 @@ packages = ["crossplane"]
 # This special environment is used by hatch fmt.
 [tool.hatch.envs.hatch-static-analysis]
 dependencies = ["ruff==0.11.2"]
-config-path = "none"           # Disable Hatch's default Ruff config.
+config-path = "none"            # Disable Hatch's default Ruff config.
 
 [tool.ruff]
 target-version = "py311"


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

You MUST either [x] check or ~strikethrough~ every item in the checklist below.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

https://typing.python.org/en/latest/spec/distributing.html#packaging-type-information https://typing.python.org/en/latest/guides/libraries.html#marking-a-package-as-providing-type-information

It turns out we need to add a py.typed file so that tools will know this library has type hints. As far as I can tell we don't need to do anything special to have our build tool (Hatch) include this file when it builds and packages the library.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Added or updated unit tests for my change.~

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
