### PR TITLE
Fix get_credentials, and move it to request

### DIFF
--- a/crossplane/function/resource.py
+++ b/crossplane/function/resource.py
@@ -140,24 +140,3 @@ def get_condition(resource: structpb.Struct, typ: str) -> Condition:
         return condition
 
     return unknown
-
-
-@dataclasses.dataclass
-class Credentials:
-    """Credentials."""
-
-    type: str
-    data: dict
-
-
-def get_credentials(req: structpb.Struct, name: str) -> Credentials:
-    """Get the supplied credentials."""
-    empty = Credentials(type="data", data={})
-    if not req or "credentials" not in req:
-        return empty
-    if not req["credentials"] or name not in req["credentials"]:
-        return empty
-    return Credentials(
-        type=req["credentials"][name]["type"],
-        data=struct_to_dict(req["credentials"][name]["data"]),
-    )

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -205,49 +205,6 @@ class TestResource(unittest.TestCase):
                 dataclasses.asdict(case.want), dataclasses.asdict(got), "-want, +got"
             )
 
-    def test_get_credentials(self) -> None:
-        @dataclasses.dataclass
-        class TestCase:
-            reason: str
-            req: structpb.Struct
-            name: str
-            want: resource.Credentials
-
-        cases = [
-            TestCase(
-                reason="Return the specified credentials if they exist.",
-                req=resource.dict_to_struct(
-                    {"credentials": {"test": {"type": "data", "data": {"foo": "bar"}}}}
-                ),
-                name="test",
-                want=resource.Credentials(type="data", data={"foo": "bar"}),
-            ),
-            TestCase(
-                reason="Return empty credentials if no credentials section exists.",
-                req=resource.dict_to_struct({}),
-                name="test",
-                want=resource.Credentials(type="data", data={}),
-            ),
-            TestCase(
-                reason="Return empty credentials if the specified name does not exist.",
-                req=resource.dict_to_struct(
-                    {
-                        "credentials": {
-                            "nottest": {"type": "data", "data": {"foo": "bar"}}
-                        }
-                    }
-                ),
-                name="test",
-                want=resource.Credentials(type="data", data={}),
-            ),
-        ]
-
-        for case in cases:
-            got = resource.get_credentials(case.req, case.name)
-            self.assertEqual(
-                dataclasses.asdict(case.want), dataclasses.asdict(got), "-want, +got"
-            )
-
     def test_dict_to_struct(self) -> None:
         @dataclasses.dataclass
         class TestCase:


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

You MUST either [x] check or ~strikethrough~ every item in the checklist below.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes https://github.com/crossplane/function-sdk-python/issues/137

I don't think this would've ever worked if passed a RunFunctionRequest due to the way field presence works in most protobuf messages. In practice I can't think why req would ever be a Struct and not a RunFunctionRequest.

CC @bobh66 has this been working for you? Looks like you added this and I reviewed it, but I missed that `req` wouldn't be a struct in practice.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
