### PR TITLE
fix: use servicer type in runtime

### DIFF
--- a/crossplane/function/runtime.py
+++ b/crossplane/function/runtime.py
@@ -70,7 +70,7 @@ def load_credentials(tls_certs_dir: str) -> grpc.ServerCredentials:
 
 
 def serve(
-    function: grpcv1.FunctionRunnerService,
+    function: grpcv1.FunctionRunnerServiceServicer,
     address: str,
     *,
     creds: grpc.ServerCredentials,
@@ -134,20 +134,20 @@ def serve(
         loop.close()
 
 
-class BetaFunctionRunner(grpcv1beta1.FunctionRunnerService):
+class BetaFunctionRunner(grpcv1beta1.FunctionRunnerServiceServicer):
     """A BetaFunctionRunner handles beta gRPC RunFunctionRequests.
 
-    It handles requests by passing them to a wrapped v1.FunctionRunnerService.
+    It handles requests by passing them to a wrapped v1.FunctionRunnerServiceServicer.
     Incoming v1beta1 requests are converted to v1 by round-tripping them through
     serialization. Outgoing requests are converted from v1 to v1beta1 the same
     way.
     """
 
-    def __init__(self, wrapped: grpcv1.FunctionRunnerService):
+    def __init__(self, wrapped: grpcv1.FunctionRunnerServiceServicer):
         """Create a new BetaFunctionRunner."""
         self.wrapped = wrapped
 
-    async def RunFunction(  # noqa: N802  # gRPC requires this name.
+    async def RunFunction(  # noqa: N802  # gRPC requires this name. # pyright: ignore[reportIncompatibleMethodOverride]
         self, req: fnv1beta1.RunFunctionRequest, context: grpc.aio.ServicerContext
     ) -> fnv1beta1.RunFunctionResponse:
         """Run the underlying function."""


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Fixes #211 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Added or updated unit tests for my change.~ This only affects type, no runtime changes

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
