### PR TITLE
Allow require_resources to match all resources of a kind

### DIFF
--- a/crossplane/function/response.py
+++ b/crossplane/function/response.py
@@ -163,13 +163,16 @@ def require_resources(  # noqa: PLR0913
         namespace: The namespace to search in (optional).
 
     Raises:
-        ValueError: If both match_name and match_labels are provided, or neither.
+        ValueError: If both match_name and match_labels are provided.
 
     This tells Crossplane to fetch the specified resources and include them
     in the next call to the function in req.required_resources[name].
+
+    If neither match_name nor match_labels is provided, all resources of the
+    given api_version and kind are matched.
     """
-    if (match_name is None) == (match_labels is None):
-        msg = "Exactly one of match_name or match_labels must be provided"
+    if match_name is not None and match_labels is not None:
+        msg = "match_name and match_labels are mutually exclusive"
         raise ValueError(msg)
 
     selector = fnv1.ResourceSelector(

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -233,6 +233,21 @@ class TestResponse(unittest.TestCase):
                     match_name="worker-1",
                 ),
             ),
+            TestCase(
+                reason="Should match all resources of a kind with no match field.",
+                rsp=fnv1.RunFunctionResponse(),
+                name="all-pods",
+                api_version="v1",
+                kind="Pod",
+                match_name=None,
+                match_labels=None,
+                namespace="default",
+                want_selector=fnv1.ResourceSelector(
+                    api_version="v1",
+                    kind="Pod",
+                    namespace="default",
+                ),
+            ),
         ]
 
         for case in cases:
@@ -268,17 +283,6 @@ class TestResponse(unittest.TestCase):
                 "Pod",
                 match_name="pod-name",
                 match_labels={"app": "test"},
-            )
-
-        # Should raise ValueError if neither match_name nor match_labels are provided
-        with self.assertRaises(ValueError):
-            response.require_resources(
-                rsp,
-                "test",
-                "v1",
-                "Pod",
-                match_name=None,
-                match_labels=None,
             )
 
     def test_require_schema(self) -> None:


### PR DESCRIPTION
### Description of your changes

`require_resources` rejected a selector with neither `match_name` nor `match_labels` set. Crossplane now treats such a selector as matching all resources of the given `apiVersion` and `kind` (crossplane/crossplane#7241).

This PR relaxes the validation to only reject `match_name` and `match_labels` both being set.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
